### PR TITLE
Add fixed structures

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,6 @@ dependencies:
   - eigen
   - pytest
   - cmake
+  - scikit-sparse
   # development dependencies
   - clangdev

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,5 @@ dependencies:
   - eigen
   - pytest
   - cmake
+  # development dependencies
+  - clangdev

--- a/src/Rigid.py
+++ b/src/Rigid.py
@@ -37,9 +37,12 @@ class RigidBody:
         kbt = 1.0  # TODO temp, do we need kbt in c_rigid at all?
 
         self.__check_configs(rigid_config, fixed_config)
+        self.fixed_config = (
+            np.array(fixed_config).flatten() if fixed_config is not None else None
+        )
 
         self.blobs_per_body = np.size(rigid_config) // 3
-        self.fixed_blobs = 0 if fixed_config is None else np.size(fixed_config) // 3
+        self.n_fixed = 0 if fixed_config is None else np.size(fixed_config) // 3
 
         self.cb.setParameters(a, dt, kbt, eta, rigid_config)
         self.cb.setBlkPC(block_PC)
@@ -61,12 +64,15 @@ class RigidBody:
         self.cb.setConfig(X, Q)
         self.cb.set_K_mats()
 
-        self.total_blobs = self.N_bodies * self.blobs_per_body + self.fixed_blobs
+        self.total_blobs = self.N_bodies * self.blobs_per_body + self.n_fixed
         self.__construct_K_mats()
 
     def get_blob_positions(self) -> np.ndarray:
         shape = (-1, 3) if len(self.X_shape) == 2 else (-1)
-        return np.array(self.cb.multi_body_pos()).reshape(shape)
+        pos = self.cb.multi_body_pos()
+        if self.fixed_config is not None:
+            pos = np.concatenate((pos, self.fixed_config.flatten()))
+        return np.reshape(pos, shape)
 
     def K_dot(self, U: vector) -> np.ndarray:
         self.__check_input_size(body_input=U)
@@ -76,13 +82,23 @@ class RigidBody:
 
     def KT_dot(self, lambda_vec: vector) -> np.ndarray:
         self.__check_input_size(blob_input=lambda_vec)
-        result = self.K_inv.dot(np.array(lambda_vec).ravel())
+        result = self.K.T.dot(np.array(lambda_vec).ravel())
         shape = (-1, 3) if np.ndim(lambda_vec) == 2 else (-1)
         return np.array(result).reshape(shape)
 
     def apply_PC(self, b: vector) -> np.ndarray:
         self.__check_input_size(system_input=b)
-        return self.cb.apply_PC(np.array(b))
+        if self.n_fixed > 0:
+            slice_ind = 3 * self.total_blobs - 3 * self.n_fixed
+            b = np.concatenate((b[0:slice_ind], b[3 * self.total_blobs :]))
+        # TODO this is wrong for fixed blobs
+        out = self.cb.apply_PC(np.array(b))
+
+        if self.n_fixed > 0:
+            out = np.concatenate(
+                (out[0:slice_ind], np.zeros(3 * self.n_fixed), out[slice_ind:])
+            )
+        return out
 
     def apply_saddle(self, x: vector) -> np.ndarray:
         self.__check_input_size(system_input=x)
@@ -98,8 +114,10 @@ class RigidBody:
     def apply_M(self, forces: vector, positions: vector) -> np.ndarray:
         if np.size(positions) != np.size(forces):
             raise RuntimeError("Positions and forces must be of the same size")
-        self.__check_input_size(blob_input=forces)
-        self.__check_input_size(blob_input=positions)
+        if np.size(forces) % 3 != 0:
+            raise RuntimeError("Forces vector size must be a multiple of 3")
+        if np.size(positions) % 3 != 0:
+            raise RuntimeError("Positions vector size must be a multiple of 3")
         shape = (-1, 3) if np.ndim(forces) == 2 and np.ndim(positions) == 2 else (-1)
 
         positions = np.array(positions).ravel()
@@ -124,12 +142,10 @@ class RigidBody:
         self.K = self.cb.get_K()
         self.K_inv = self.cb.get_Kinv()
 
-        if self.fixed_blobs > 0:
+        if self.n_fixed > 0:
             padded_shape = (3 * self.total_blobs, 6 * self.N_bodies)
             self.K.resize(padded_shape)
             self.K_inv.resize(padded_shape)
-            # self.K = sp.csc_matrix(self.K, shape=padded_shape)
-            # self.K_inv = sp.csc_matrix(self.K_inv, shape=padded_shape)
 
     def __check_configs(
         self, rigid_config: vector, fixed_config: vector | None

--- a/src/Rigid.py
+++ b/src/Rigid.py
@@ -1,8 +1,10 @@
 from Rigid import c_rigid as crigid
 import numpy as np
 from typing import TypeAlias
+import scipy.sparse as sp
 
 vector: TypeAlias = list | np.ndarray
+sparse_m: TypeAlias = sp.csc_matrix
 """Rigid body interface for Python.
 
 Dev notes:
@@ -13,6 +15,8 @@ Dev notes:
 class RigidBody:
     X_shape: tuple[int, ...]
     Q_shape: tuple[int, ...]
+    K: sparse_m
+    K_inv: sparse_m
 
     def __init__(
         self,
@@ -22,6 +26,7 @@ class RigidBody:
         a: float,
         eta: float,
         dt: float,
+        fixed_config: vector | None = None,
         wall_PC=False,
         block_PC=False,
     ):
@@ -31,11 +36,10 @@ class RigidBody:
 
         kbt = 1.0  # TODO temp, do we need kbt in c_rigid at all?
 
-        if np.size(rigid_config) % 3 != 0:
-            raise RuntimeError(
-                f"Rigid config must have length 3N. Rigid config shape: {np.shape(rigid_config)}"
-            )
+        self.__check_configs(rigid_config, fixed_config)
+
         self.blobs_per_body = np.size(rigid_config) // 3
+        self.fixed_blobs = 0 if fixed_config is None else np.size(fixed_config) // 3
 
         self.cb.setParameters(a, dt, kbt, eta, rigid_config)
         self.cb.setBlkPC(block_PC)
@@ -57,7 +61,9 @@ class RigidBody:
         self.cb.setConfig(X, Q)
         self.cb.set_K_mats()
 
-        self.total_blobs = self.N_bodies * self.blobs_per_body
+        self.__construct_K_mats()
+
+        self.total_blobs = self.N_bodies * self.blobs_per_body + self.fixed_blobs
 
     def get_blob_positions(self) -> np.ndarray:
         shape = (-1, 3) if len(self.X_shape) == 2 else (-1)
@@ -65,15 +71,15 @@ class RigidBody:
 
     def K_dot(self, U: vector) -> np.ndarray:
         self.__check_input_size(U_vec=U)
-        result = self.cb.K_x_U(np.array(U).ravel())
+        result = self.K.dot(np.array(U).ravel())
         shape = (-1, 3) if np.ndim(U) == 2 else (-1)
-        return result.reshape(shape)
+        return np.array(result).reshape(shape)
 
     def KT_dot(self, lambda_vec: vector) -> np.ndarray:
         self.__check_input_size(lambda_vec=lambda_vec)
-        result = self.cb.KT_x_Lam(np.array(lambda_vec).ravel())
+        result = self.K_inv.dot(np.array(lambda_vec).ravel())
         shape = (-1, 3) if np.ndim(lambda_vec) == 2 else (-1)
-        return result.reshape(shape)
+        return np.array(result).reshape(shape)
 
     def apply_PC(self, b: vector) -> np.ndarray:
         self.__check_input_size(system_input=b)
@@ -104,15 +110,37 @@ class RigidBody:
 
         return self.cb.apply_M(np.reshape(forces, (-1)), np.reshape(positions, (-1)))
 
-    def get_K(self) -> np.ndarray:
-        return self.cb.get_K()
+    def get_K(self) -> sparse_m:
+        return self.K
 
-    def get_Kinv(self) -> np.ndarray:
-        return self.cb.get_Kinv()
+    def get_Kinv(self) -> sparse_m:
+        return self.K_inv
 
     def evolve_rigid_bodies(self, U: vector) -> None:
         self.__check_input_size(U_vec=U)
         self.cb.evolve_X_Q(np.array(U).ravel())
+
+    def __construct_K_mats(self):
+        self.K = self.cb.get_K()
+        self.K_inv = self.cb.get_Kinv()
+
+        if self.fixed_blobs > 0:
+            padded_shape = (3 * self.total_blobs, 6 * self.N_bodies)
+            self.K = sp.csc_matrix(self.K, shape=padded_shape)
+            self.K_inv = sp.csc_matrix(self.K_inv, shape=padded_shape)
+
+    def __check_configs(
+        self, rigid_config: vector, fixed_config: vector | None
+    ) -> None:
+        if np.size(rigid_config) % 3 != 0:
+            raise RuntimeError(
+                f"Rigid config must have length 3N. Rigid config size: {np.size(rigid_config)}"
+            )
+        if fixed_config is not None:
+            if np.size(fixed_config) % 3 != 0:
+                raise RuntimeError(
+                    f"Fixed config must have length 3N. Fixed config size: {np.size(fixed_config)}"
+                )
 
     def __check_and_set_configs(self, X: vector, Q: vector) -> None:
         x_size = np.prod(np.shape(X))

--- a/src/Rigid.py
+++ b/src/Rigid.py
@@ -127,7 +127,7 @@ class RigidBody:
             self.apply_M(forces=lambda_vec, positions=r_vecs) - self.K_dot(U).flatten()
         )
         F = self.KT_dot(lambda_vec).flatten()
-        return np.concatenate((slip, F))
+        return np.concatenate((slip, -F))
 
     def apply_M(self, forces: vector, positions: vector) -> np.ndarray:
         if np.size(positions) != np.size(forces):

--- a/src/Rigid.py
+++ b/src/Rigid.py
@@ -69,13 +69,13 @@ class RigidBody:
         return np.array(self.cb.multi_body_pos()).reshape(shape)
 
     def K_dot(self, U: vector) -> np.ndarray:
-        self.__check_input_size(U_vec=U)
+        self.__check_input_size(body_input=U)
         result = self.K.dot(np.array(U).ravel())
         shape = (-1, 3) if np.ndim(U) == 2 else (-1)
         return np.array(result).reshape(shape)
 
     def KT_dot(self, lambda_vec: vector) -> np.ndarray:
-        self.__check_input_size(lambda_vec=lambda_vec)
+        self.__check_input_size(blob_input=lambda_vec)
         result = self.K_inv.dot(np.array(lambda_vec).ravel())
         shape = (-1, 3) if np.ndim(lambda_vec) == 2 else (-1)
         return np.array(result).reshape(shape)
@@ -98,8 +98,9 @@ class RigidBody:
     def apply_M(self, forces: vector, positions: vector) -> np.ndarray:
         if np.size(positions) != np.size(forces):
             raise RuntimeError("Positions and forces must be of the same size")
-        if np.size(forces) % 3 != 0 or np.size(positions) % 3 != 0:
-            raise RuntimeError("Forces and positions must have total size 3*N_blobs")
+        self.__check_input_size(blob_input=forces)
+        self.__check_input_size(blob_input=positions)
+        shape = (-1, 3) if np.ndim(forces) == 2 and np.ndim(positions) == 2 else (-1)
 
         positions = np.array(positions).ravel()
         if self.using_wall and np.any(positions[2::3] <= 0):
@@ -107,7 +108,7 @@ class RigidBody:
                 "Particle detected at or below wall (z <= 0) in apply_M. Either remove the wall or ensure all particles are above the wall."
             )
 
-        return self.cb.apply_M(np.reshape(forces, (-1)), np.reshape(positions, (-1)))
+        return self.cb.apply_M(np.reshape(forces, (-1)), positions).reshape(shape)
 
     def get_K(self) -> sparse_m:
         return self.K
@@ -116,7 +117,7 @@ class RigidBody:
         return self.K_inv
 
     def evolve_rigid_bodies(self, U: vector) -> None:
-        self.__check_input_size(U_vec=U)
+        self.__check_input_size(body_input=U)
         self.cb.evolve_X_Q(np.array(U).ravel())
 
     def __construct_K_mats(self):
@@ -164,19 +165,19 @@ class RigidBody:
 
     def __check_input_size(
         self,
-        lambda_vec: vector | None = None,
-        U_vec: vector | None = None,
+        blob_input: vector | None = None,
+        body_input: vector | None = None,
         system_input: vector | None = None,
     ):
-        if lambda_vec is not None:
-            if np.size(lambda_vec) != 3 * self.total_blobs:
+        if blob_input is not None:
+            if np.size(blob_input) != 3 * self.total_blobs:
                 raise RuntimeError(
-                    f"lambda must have total size 3*N_blobs = {3 * self.total_blobs}. lambda_vec shape: {np.shape(lambda_vec)}"
+                    f"lambda must have total size 3*N_blobs = {3 * self.total_blobs}. lambda_vec shape: {np.shape(blob_input)}"
                 )
-        if U_vec is not None:
-            if np.size(U_vec) != 6 * self.N_bodies:
+        if body_input is not None:
+            if np.size(body_input) != 6 * self.N_bodies:
                 raise RuntimeError(
-                    f"U must have total size 6*N_bodies = {6*self.N_bodies}. U shape: {np.shape(U_vec)}"
+                    f"U must have total size 6*N_bodies = {6*self.N_bodies}. U shape: {np.shape(body_input)}"
                 )
 
         if system_input is not None:

--- a/src/Rigid.py
+++ b/src/Rigid.py
@@ -61,9 +61,8 @@ class RigidBody:
         self.cb.setConfig(X, Q)
         self.cb.set_K_mats()
 
-        self.__construct_K_mats()
-
         self.total_blobs = self.N_bodies * self.blobs_per_body + self.fixed_blobs
+        self.__construct_K_mats()
 
     def get_blob_positions(self) -> np.ndarray:
         shape = (-1, 3) if len(self.X_shape) == 2 else (-1)
@@ -126,8 +125,10 @@ class RigidBody:
 
         if self.fixed_blobs > 0:
             padded_shape = (3 * self.total_blobs, 6 * self.N_bodies)
-            self.K = sp.csc_matrix(self.K, shape=padded_shape)
-            self.K_inv = sp.csc_matrix(self.K_inv, shape=padded_shape)
+            self.K.resize(padded_shape)
+            self.K_inv.resize(padded_shape)
+            # self.K = sp.csc_matrix(self.K, shape=padded_shape)
+            # self.K_inv = sp.csc_matrix(self.K_inv, shape=padded_shape)
 
     def __check_configs(
         self, rigid_config: vector, fixed_config: vector | None

--- a/src/Rigid.py
+++ b/src/Rigid.py
@@ -44,7 +44,7 @@ class RigidBody:
             np.array(fixed_config).flatten() if fixed_config is not None else None
         )
 
-        self.blobs_per_body = np.size(rigid_config) // 3
+        self.blobs_per_rigid_body = np.size(rigid_config) // 3
         self.n_fixed = 0 if fixed_config is None else np.size(fixed_config) // 3
 
         self.cb.setParameters(a, dt, kbt, eta, rigid_config)
@@ -68,7 +68,7 @@ class RigidBody:
         self.cb.setConfig(X, Q)
         self.cb.set_K_mats()
 
-        self.total_blobs = self.N_bodies * self.blobs_per_body + self.n_fixed
+        self.total_blobs = self.N_bodies * self.blobs_per_rigid_body + self.n_fixed
         self.__construct_K_mats()
 
     def get_blob_positions(self) -> np.ndarray:

--- a/src/Rigid.py
+++ b/src/Rigid.py
@@ -2,6 +2,7 @@ from Rigid import c_rigid as crigid
 import numpy as np
 from typing import TypeAlias
 import scipy.sparse as sp
+from sksparse.cholmod import cholesky
 
 vector: TypeAlias = list | np.ndarray
 sparse_m: TypeAlias = sp.csc_matrix
@@ -35,6 +36,8 @@ class RigidBody:
         self.using_wall = wall_PC
 
         kbt = 1.0  # TODO temp, do we need kbt in c_rigid at all?
+        self.eta = eta
+        self.a = a
 
         self.__check_configs(rigid_config, fixed_config)
         self.fixed_config = (
@@ -47,6 +50,7 @@ class RigidBody:
         self.cb.setParameters(a, dt, kbt, eta, rigid_config)
         self.cb.setBlkPC(block_PC)
         self.cb.setWallPC(wall_PC)
+        self.PC = None
 
         self.set_config(X, Q)
 
@@ -88,17 +92,31 @@ class RigidBody:
 
     def apply_PC(self, b: vector) -> np.ndarray:
         self.__check_input_size(system_input=b)
-        if self.n_fixed > 0:
-            slice_ind = 3 * self.total_blobs - 3 * self.n_fixed
-            b = np.concatenate((b[0:slice_ind], b[3 * self.total_blobs :]))
-        # TODO this is wrong for fixed blobs
-        out = self.cb.apply_PC(np.array(b))
-
-        if self.n_fixed > 0:
-            out = np.concatenate(
-                (out[0:slice_ind], np.zeros(3 * self.n_fixed), out[slice_ind:])
-            )
+        # note: currently a fixed config ignores wall_PC and block_PC
+        if self.fixed_config is not None:
+            out = self.apply_PC_diag(b)
+        else:
+            out = self.cb.apply_PC(np.array(b))
         return out
+
+    def apply_PC_diag(self, b: vector) -> np.ndarray:
+        self.__check_input_size(system_input=b)
+        if self.PC is None:
+            self.build_block_PC()
+
+        test = self.PC.solve_A(np.array(b).ravel())
+        return test.astype(self.precision)
+
+    def build_block_PC(self):
+        K = self.get_K()
+        M0 = sp.diags(
+            [1 / (6 * np.pi * self.eta * self.a)] * 3 * self.total_blobs,
+            shape=(3 * self.total_blobs, 3 * self.total_blobs),
+        )
+        PC_block = sp.block_array(
+            [[M0, -K], [-K.T, None]], dtype=self.precision
+        ).tocsc()
+        self.PC = cholesky(PC_block)
 
     def apply_saddle(self, x: vector) -> np.ndarray:
         self.__check_input_size(system_input=x)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,14 +1,11 @@
 import numpy as np
-from Rigid import RigidBody
-import scipy.sparse as sp
 import utils
-import time
 from pyamg.krylov import gmres
 from scipy.sparse.linalg import LinearOperator
-from scipy.spatial.distance import pdist
 
 
 # solve the system with fixed blobs and check that the velocity of the fixed blobs is close to zero.
+# the configuration is two multiblob particles with a (fixed) wall between them
 def test_apply_with_fixed():
     X = np.array([[-2.0, 0.0, 1.5], [2.0, 0.0, 1.5]])
     Q = np.array([[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]])
@@ -34,7 +31,6 @@ def test_apply_with_fixed():
     RHS = np.random.rand(sz).astype(cb.precision)
     RHS[3 * len(config) : 3 * cb.total_blobs] = 0.0
     RHS_norm = np.linalg.norm(RHS)
-    print("precision:", cb.precision)
 
     A = LinearOperator(shape=(sz, sz), matvec=cb.apply_saddle, dtype=cb.precision)
     PC = LinearOperator(shape=(sz, sz), matvec=cb.apply_PC, dtype=cb.precision)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -36,7 +36,7 @@ def test_apply_with_fixed():
     PC = LinearOperator(shape=(sz, sz), matvec=cb.apply_PC, dtype=cb.precision)
     tol = 1e-4
     res_norms = []
-    (sol, _) = gmres(
+    sol, _ = gmres(
         A,
         (RHS / RHS_norm),
         M=PC,
@@ -50,6 +50,6 @@ def test_apply_with_fixed():
 
     v = cb.apply_M(lambda_vec, cb.get_blob_positions())
 
-    v_fixed = v[3 * cb.blobs_per_body * cb.N_bodies :]
+    v_fixed = v[3 * cb.blobs_per_rigid_body * cb.N_bodies :]
     mob_fact = 6 * np.pi * cb.eta * cb.a
     assert np.all(np.abs(v_fixed) < 10 * tol / mob_fact)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,0 +1,59 @@
+import numpy as np
+from Rigid import RigidBody
+import scipy.sparse as sp
+import utils
+import time
+from pyamg.krylov import gmres
+from scipy.sparse.linalg import LinearOperator
+from scipy.spatial.distance import pdist
+
+
+# solve the system with fixed blobs and check that the velocity of the fixed blobs is close to zero.
+def test_apply_with_fixed():
+    X = np.array([[-2.0, 0.0, 1.5], [2.0, 0.0, 1.5]])
+    Q = np.array([[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]])
+    params, config = utils.load_config(utils.struct_shell_12)
+
+    a = 0.5 * params["sep"]
+    wall_x = 0.0
+    wall_y = np.arange(-5.0, 5.0, 2 * a)
+    wall_z = np.arange(a, 5.0, 2 * a)
+    wall_X, wall_Y, wall_Z = np.meshgrid(wall_x, wall_y, wall_z)
+    fixed_wall = np.column_stack((wall_X.flatten(), wall_Y.flatten(), wall_Z.flatten()))
+    cb = utils.create_solver(
+        X=X,
+        Q=Q,
+        rigid_config=config,
+        fixed_config=fixed_wall,
+        a=a,
+        eta=1e-3,
+        wall_PC=False,
+    )
+
+    sz = int(3 * cb.total_blobs + 6 * cb.N_bodies)
+    RHS = np.random.rand(sz).astype(cb.precision)
+    RHS[3 * len(config) : 3 * cb.total_blobs] = 0.0
+    RHS_norm = np.linalg.norm(RHS)
+    print("precision:", cb.precision)
+
+    A = LinearOperator(shape=(sz, sz), matvec=cb.apply_saddle, dtype=cb.precision)
+    PC = LinearOperator(shape=(sz, sz), matvec=cb.apply_PC, dtype=cb.precision)
+    tol = 1e-4
+    res_norms = []
+    (sol, _) = gmres(
+        A,
+        (RHS / RHS_norm),
+        M=PC,
+        x0=None,
+        tol=tol,
+        callback=lambda rk: res_norms.append(np.linalg.norm(rk)),
+    )
+    sol *= RHS_norm
+
+    lambda_vec = sol[: 3 * cb.total_blobs]
+
+    v = cb.apply_M(lambda_vec, cb.get_blob_positions())
+
+    v_fixed = v[3 * cb.blobs_per_body * cb.N_bodies :]
+    mob_fact = 6 * np.pi * cb.eta * cb.a
+    assert np.all(np.abs(v_fixed) < 10 * tol / mob_fact)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -90,14 +90,19 @@ def test_all(vector_type, flat_inputs, include_fixed):
     cb = utils.create_solver(rigid_config=config, X=X, Q=Q, fixed_config=fixed_config)
     blobs_per_body = config.shape[0]
 
-    # TODO: include apply_M. evolve probably stays stand-alone since it has no direct outputs
+    # TODO: include evolve?
     # TODO: also need to modify this for include_fixed=True
+    blob_vec = np.random.randn(3 * blobs_per_body * N_rigid)
+    M_pos = lambda pos: cb.apply_M(blob_vec, pos)
+    M_force = lambda force: cb.apply_M(force, blob_vec)
+
     funcs_to_input = {
         cb.K_dot: {"input_type": "body", "output_type": "blob"},
         cb.KT_dot: {"input_type": "blob", "output_type": "body"},
         cb.apply_PC: {"input_type": "system", "output_type": "system"},
         cb.apply_saddle: {"input_type": "system", "output_type": "system"},
-        # cb.apply_M: {"input_type": "blob", "output_type": "blob"},
+        M_pos: {"input_type": "blob", "output_type": "blob"},
+        M_force: {"input_type": "blob", "output_type": "blob"},
         # cb.evolve_rigid_bodies: {"input_type": "body", "output_type": "body"},
     }
     type_mapping = {
@@ -110,23 +115,23 @@ def test_all(vector_type, flat_inputs, include_fixed):
         out_size = type_mapping[types["output_type"]]
 
         input_vec = np.random.randn(in_size)
-        if flat_inputs and types["input_type"] != "system":
-            if types["input_type"] == "body":
-                input_vec = np.reshape(input_vec, (-1, 6))
-                out_shape = (blobs_per_body * N_rigid, 3)
-            elif types["input_type"] == "blob":
+        if not flat_inputs:
+            if types["input_type"] != "system":
                 input_vec = np.reshape(input_vec, (-1, 3))
-                out_shape = (2 * N_rigid, 3)
+            if types["output_type"] != "system":
+                out_shape = (out_size // 3, 3)
+            else:
+                out_shape = (out_size,)
         else:
             out_shape = (out_size,)
+        blob_vec = np.reshape(blob_vec, (-1, 3)) if not flat_inputs else blob_vec
 
         result = func(vector_type(input_vec))
-        msg = "func: {}, expected output shape: {}, got shape: {}".format(
+        fail_msg = "func: {}, expected output shape: {}, got shape: {}".format(
             func.__name__, out_shape, np.shape(result)
         )
-        assert np.shape(result) == out_shape, msg
+        assert np.shape(result) == out_shape, fail_msg
         assert np.linalg.norm(result) > 0.0
-    pass
 
 
 @pytest.mark.parametrize("vector_type", (list, np.array))

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -78,21 +78,31 @@ def test_blob_positions():
     assert np.allclose(pos, ref_pos, atol=1e-5)
 
 
+@pytest.mark.parametrize(
+    ("block_PC", "wall_PC"),
+    ((False, False), (True, False), (False, True), (True, True)),
+)
 @pytest.mark.parametrize("vector_type", (list, np.array))
 @pytest.mark.parametrize("flat_inputs", [True, False])
 # @pytest.mark.parametrize("include_fixed", [True, False])
 @pytest.mark.parametrize("include_fixed", [False])
-def test_all(vector_type, flat_inputs, include_fixed):
+def test_all(block_PC, wall_PC, vector_type, flat_inputs, include_fixed):
     N_rigid = 3
-    X, Q = utils.create_random_positions(N_rigid)
+    X, Q = utils.create_random_positions(N_rigid, wall_PC=wall_PC)
     _, config = utils.load_config(utils.struct_shell_12)
     fixed_config = np.random.randn(3, 3) if include_fixed else None
-    cb = utils.create_solver(rigid_config=config, X=X, Q=Q, fixed_config=fixed_config)
+    cb = utils.create_solver(
+        rigid_config=config,
+        X=X,
+        Q=Q,
+        fixed_config=fixed_config,
+        block_PC=block_PC,
+        wall_PC=wall_PC,
+    )
     blobs_per_body = config.shape[0]
 
-    # TODO: include evolve?
     # TODO: also need to modify this for include_fixed=True
-    blob_vec = np.random.randn(3 * blobs_per_body * N_rigid)
+    blob_vec = cb.get_blob_positions().flatten()
     M_pos = lambda pos: cb.apply_M(blob_vec, pos)
     M_force = lambda force: cb.apply_M(force, blob_vec)
 
@@ -103,7 +113,6 @@ def test_all(vector_type, flat_inputs, include_fixed):
         cb.apply_saddle: {"input_type": "system", "output_type": "system"},
         M_pos: {"input_type": "blob", "output_type": "blob"},
         M_force: {"input_type": "blob", "output_type": "blob"},
-        # cb.evolve_rigid_bodies: {"input_type": "body", "output_type": "body"},
     }
     type_mapping = {
         "body": 6 * N_rigid,
@@ -114,7 +123,7 @@ def test_all(vector_type, flat_inputs, include_fixed):
         in_size = type_mapping[types["input_type"]]
         out_size = type_mapping[types["output_type"]]
 
-        input_vec = np.random.randn(in_size)
+        input_vec = np.random.uniform(1, 10, in_size)
         if not flat_inputs:
             if types["input_type"] != "system":
                 input_vec = np.reshape(input_vec, (-1, 3))
@@ -133,55 +142,9 @@ def test_all(vector_type, flat_inputs, include_fixed):
         assert np.shape(result) == out_shape, fail_msg
         assert np.linalg.norm(result) > 0.0
 
-
-@pytest.mark.parametrize("vector_type", (list, np.array))
-@pytest.mark.parametrize("flat_inputs", [False, True])
-def test_K_dot(vector_type, flat_inputs):
-    N_rigid = 3
-    X, Q = utils.create_random_positions(N_rigid)
-    _, config = utils.load_config(utils.struct_shell_12)
-    cb = utils.create_solver(rigid_config=config, X=X, Q=Q)
-    blobs_per_body = config.shape[0]
-
-    U_bad_size = vector_type(np.random.randn(6 * N_rigid - 3))
-    with pytest.raises(RuntimeError):
-        cb.K_dot(U_bad_size)
-
-    U_vec = np.random.randn(6 * N_rigid)
-    if flat_inputs:
-        out_shape = (3 * blobs_per_body * N_rigid,)
-    else:
-        U_vec = np.reshape(U_vec, (-1, 6))
-        out_shape = (blobs_per_body * N_rigid, 3)
-
-    result = cb.K_dot(vector_type(U_vec))
-    assert result.shape == out_shape
-    assert np.linalg.norm(result) > 0.0
-
-
-@pytest.mark.parametrize("vector_type", (list, np.array))
-@pytest.mark.parametrize("flat_inputs", [False, True])
-def test_KT_dot(vector_type, flat_inputs):
-    N_rigid = 3
-    X, Q = utils.create_random_positions(N_rigid)
-    _, config = utils.load_config(utils.struct_shell_12)
-    cb = utils.create_solver(rigid_config=config, X=X, Q=Q)
-    blobs_per_body = config.shape[0]
-
-    lambda_bad_size = vector_type(np.random.randn(3 * blobs_per_body * N_rigid - 5))
-    with pytest.raises(RuntimeError):
-        cb.KT_dot(lambda_bad_size)
-
-    lambda_vec = np.random.randn(3 * blobs_per_body * N_rigid)
-    if flat_inputs:
-        out_shape = (6 * N_rigid,)
-    else:
-        lambda_vec = np.reshape(lambda_vec, (-1, 3))
-        out_shape = (2 * N_rigid, 3)
-    result = cb.KT_dot(vector_type(lambda_vec))
-    print("result shape:", (result.shape), "lambda_vec shape:", np.shape(lambda_vec))
-    assert result.shape == out_shape
-    assert np.linalg.norm(result) > 0.0
+        input_bad = input_vec[:-2]
+        with pytest.raises(RuntimeError):
+            func(vector_type(input_bad))
 
 
 def test_get_K_Kinv():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -79,6 +79,57 @@ def test_blob_positions():
 
 
 @pytest.mark.parametrize("vector_type", (list, np.array))
+@pytest.mark.parametrize("flat_inputs", [True, False])
+# @pytest.mark.parametrize("include_fixed", [True, False])
+@pytest.mark.parametrize("include_fixed", [False])
+def test_all(vector_type, flat_inputs, include_fixed):
+    N_rigid = 3
+    X, Q = utils.create_random_positions(N_rigid)
+    _, config = utils.load_config(utils.struct_shell_12)
+    fixed_config = np.random.randn(3, 3) if include_fixed else None
+    cb = utils.create_solver(rigid_config=config, X=X, Q=Q, fixed_config=fixed_config)
+    blobs_per_body = config.shape[0]
+
+    # TODO: include apply_M. evolve probably stays stand-alone since it has no direct outputs
+    # TODO: also need to modify this for include_fixed=True
+    funcs_to_input = {
+        cb.K_dot: {"input_type": "body", "output_type": "blob"},
+        cb.KT_dot: {"input_type": "blob", "output_type": "body"},
+        cb.apply_PC: {"input_type": "system", "output_type": "system"},
+        cb.apply_saddle: {"input_type": "system", "output_type": "system"},
+        # cb.apply_M: {"input_type": "blob", "output_type": "blob"},
+        # cb.evolve_rigid_bodies: {"input_type": "body", "output_type": "body"},
+    }
+    type_mapping = {
+        "body": 6 * N_rigid,
+        "blob": 3 * blobs_per_body * N_rigid,
+        "system": 3 * blobs_per_body * N_rigid + 6 * N_rigid,
+    }
+    for func, types in funcs_to_input.items():
+        in_size = type_mapping[types["input_type"]]
+        out_size = type_mapping[types["output_type"]]
+
+        input_vec = np.random.randn(in_size)
+        if flat_inputs and types["input_type"] != "system":
+            if types["input_type"] == "body":
+                input_vec = np.reshape(input_vec, (-1, 6))
+                out_shape = (blobs_per_body * N_rigid, 3)
+            elif types["input_type"] == "blob":
+                input_vec = np.reshape(input_vec, (-1, 3))
+                out_shape = (2 * N_rigid, 3)
+        else:
+            out_shape = (out_size,)
+
+        result = func(vector_type(input_vec))
+        msg = "func: {}, expected output shape: {}, got shape: {}".format(
+            func.__name__, out_shape, np.shape(result)
+        )
+        assert np.shape(result) == out_shape, msg
+        assert np.linalg.norm(result) > 0.0
+    pass
+
+
+@pytest.mark.parametrize("vector_type", (list, np.array))
 @pytest.mark.parametrize("flat_inputs", [False, True])
 def test_K_dot(vector_type, flat_inputs):
     N_rigid = 3

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -155,11 +155,8 @@ def test_get_K_Kinv():
     _, config = utils.load_config(utils.struct_shell_12)
     cb = utils.create_solver(rigid_config=config, X=X, Q=Q)
 
-    K = np.array(cb.get_K())
-    K_inv = np.array(cb.get_Kinv())
-
-    assert np.sum(np.abs(K)) > 0.0
-    assert np.sum(np.abs(K_inv)) > 0.0
+    assert np.sum(cb.get_K()) > 0.0
+    assert np.sum(cb.get_Kinv()) > 0.0
 
 
 @pytest.mark.parametrize("vector_type", (list, np.array))

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -62,18 +62,21 @@ def test_blob_positions():
     X, Q = utils.create_random_positions(N)
     _, config = utils.load_config(utils.struct_shell_12)
     blobs_per_body = config.shape[0]
-    cb = utils.create_solver(rigid_config=config, X=X, Q=Q)
+    n_fixed = 3
+    fixed_config = np.random.uniform(0, 1, (n_fixed, 3))
+    cb = utils.create_solver(rigid_config=config, X=X, Q=Q, fixed_config=fixed_config)
 
-    N_blobs = N * blobs_per_body
+    n_blobs = N * blobs_per_body + n_fixed
     pos = cb.get_blob_positions()
-    assert pos.shape == (N_blobs, 3)
+    assert pos.shape == (n_blobs, 3)
 
-    ref_pos = np.zeros((N_blobs, 3))
+    ref_pos = np.zeros((n_blobs, 3))
     for i in range(N):
         x_i = X[i, :]
         r_i = Rotation.from_quat(Q[i, :], scalar_first=True)
         pos_i = r_i.apply(config.copy()) + x_i
         ref_pos[i * blobs_per_body : (i + 1) * blobs_per_body, :] = pos_i
+    ref_pos[N * blobs_per_body :, :] = fixed_config
 
     assert np.allclose(pos, ref_pos, atol=1e-5)
 
@@ -84,13 +87,13 @@ def test_blob_positions():
 )
 @pytest.mark.parametrize("vector_type", (list, np.array))
 @pytest.mark.parametrize("flat_inputs", [True, False])
-# @pytest.mark.parametrize("include_fixed", [True, False])
-@pytest.mark.parametrize("include_fixed", [False])
-def test_all(block_PC, wall_PC, vector_type, flat_inputs, include_fixed):
+@pytest.mark.parametrize("include_fixed", [True, False])
+def test_operator_shapes(block_PC, wall_PC, vector_type, flat_inputs, include_fixed):
     N_rigid = 3
     X, Q = utils.create_random_positions(N_rigid, wall_PC=wall_PC)
     _, config = utils.load_config(utils.struct_shell_12)
-    fixed_config = np.random.randn(3, 3) if include_fixed else None
+    n_fixed = 3 if include_fixed else 0
+    fixed_config = np.random.uniform(0, 1, (n_fixed, 3)) if include_fixed else None
     cb = utils.create_solver(
         rigid_config=config,
         X=X,
@@ -101,8 +104,7 @@ def test_all(block_PC, wall_PC, vector_type, flat_inputs, include_fixed):
     )
     blobs_per_body = config.shape[0]
 
-    # TODO: also need to modify this for include_fixed=True
-    blob_vec = cb.get_blob_positions().flatten()
+    blob_vec = np.random.uniform(1, 10, 3 * (blobs_per_body * N_rigid + n_fixed))
     M_pos = lambda pos: cb.apply_M(blob_vec, pos)
     M_force = lambda force: cb.apply_M(force, blob_vec)
 
@@ -116,8 +118,8 @@ def test_all(block_PC, wall_PC, vector_type, flat_inputs, include_fixed):
     }
     type_mapping = {
         "body": 6 * N_rigid,
-        "blob": 3 * blobs_per_body * N_rigid,
-        "system": 3 * blobs_per_body * N_rigid + 6 * N_rigid,
+        "blob": 3 * (blobs_per_body * N_rigid + n_fixed),
+        "system": 3 * (blobs_per_body * N_rigid + n_fixed) + 6 * N_rigid,
     }
     for func, types in funcs_to_input.items():
         in_size = type_mapping[types["input_type"]]
@@ -160,35 +162,6 @@ def test_get_K_Kinv():
     assert np.sum(np.abs(K_inv)) > 0.0
 
 
-@pytest.mark.parametrize(
-    ("block_PC", "wall_PC"),
-    ((False, False), (True, False), (False, True), (True, True)),
-)
-@pytest.mark.parametrize("vector_type", (list, np.array))
-def test_apply_PC(block_PC, wall_PC, vector_type):
-    N_rigid = 3
-    X, Q = utils.create_random_positions(N_rigid, wall_PC=wall_PC)
-    _, config = utils.load_config(utils.struct_shell_12)
-    cb = utils.create_solver(
-        rigid_config=config, X=X, Q=Q, block_PC=block_PC, wall_PC=wall_PC
-    )
-    blobs_per_body = config.shape[0]
-
-    size = 3 * blobs_per_body * N_rigid + 6 * N_rigid
-    b = np.random.randn(size)
-    PC = cb.apply_PC(vector_type(b))
-
-    assert PC.shape == (size,)
-    assert np.linalg.norm(PC) > 0.0
-
-    with pytest.raises(RuntimeError):
-        b_bad_size = np.random.randn(size - 4)
-        cb.apply_PC(vector_type(b_bad_size))
-    with pytest.raises(RuntimeError):
-        b_bad_shape = np.random.randn(size).reshape(-1, 3)
-        cb.apply_PC(vector_type(b_bad_shape))
-
-
 @pytest.mark.parametrize("vector_type", (list, np.array))
 @pytest.mark.parametrize("flat_inputs", [False, True])
 def test_apply_M(vector_type, flat_inputs):
@@ -218,15 +191,24 @@ def test_apply_M(vector_type, flat_inputs):
         pos = np.reshape(pos, (-1, 3))
     print(type(F))
     result = cb.apply_M(vector_type(F), vector_type(pos))
-    shape = (3 * blobs_per_body * N_rigid,)
+    shape = (
+        (3 * blobs_per_body * N_rigid,)
+        if flat_inputs
+        else (blobs_per_body * N_rigid, 3)
+    )
     assert result.shape == shape
     assert np.linalg.norm(result) > 0.0
 
     # check that we can also apply to a longer vector (e.g., if we have extra blobs)
-    F = vector_type(np.random.randn(3 * blobs_per_body * N_rigid + 3))
-    pos = vector_type(np.random.randn(3 * blobs_per_body * N_rigid + 3))
+    shape = (
+        (3 * blobs_per_body * N_rigid + 3,)
+        if flat_inputs
+        else ((blobs_per_body * N_rigid + 1), 3)
+    )
+    F = vector_type(np.random.randn(3 * blobs_per_body * N_rigid + 3).reshape(shape))
+    pos = vector_type(np.random.randn(3 * blobs_per_body * N_rigid + 3).reshape(shape))
     result_long = cb.apply_M(F, pos)
-    shape = (3 * blobs_per_body * N_rigid + 3,)
+
     assert result_long.shape == shape
     assert np.linalg.norm(result_long) > 0.0
 
@@ -244,30 +226,6 @@ def test_apply_M_with_wall():
     pos = cb.get_blob_positions()
     with pytest.raises(RuntimeError):
         cb.apply_M(F, pos)
-
-
-@pytest.mark.parametrize("vector_type", (list, np.array))
-def test_apply_saddle(vector_type):
-    N_rigid = 2
-    X, Q = utils.create_random_positions(N_rigid)
-    _, config = utils.load_config(utils.struct_shell_12)
-    cb = utils.create_solver(rigid_config=config, X=X, Q=Q)
-    blobs_per_body = config.shape[0]
-
-    size = 3 * blobs_per_body * N_rigid + 6 * N_rigid
-    x = np.random.randn(size)
-
-    out = cb.apply_saddle(x)
-    assert out.shape == (size,)
-    assert np.linalg.norm(out) > 0.0
-
-    x_bad_size = np.random.randn(size - 2)
-    with pytest.raises(RuntimeError):
-        cb.apply_saddle(x_bad_size)
-
-    x_bad_shape = np.random.randn(size).reshape(-1, 3)
-    with pytest.raises(RuntimeError):
-        cb.apply_saddle(vector_type(x_bad_shape))
 
 
 @pytest.mark.parametrize("vector_type", (list, np.array))

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -134,8 +134,8 @@ def test_get_K_Kinv():
     _, config = utils.load_config(utils.struct_shell_12)
     cb = utils.create_solver(rigid_config=config, X=X, Q=Q)
 
-    K = cb.get_K()
-    K_inv = cb.get_Kinv()
+    K = np.array(cb.get_K())
+    K_inv = np.array(cb.get_Kinv())
 
     assert np.sum(np.abs(K)) > 0.0
     assert np.sum(np.abs(K_inv)) > 0.0

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -13,7 +13,7 @@ def test_precision(precision):
     cb = utils.create_solver(X, Q)
     cb.set_config(X, Q)
 
-    N_per = cb.blobs_per_body
+    N_per = cb.blobs_per_rigid_body
     N_blobs = N_rigid * N_per
 
     U = np.random.randn(6 * N_rigid).astype(precision)
@@ -37,7 +37,7 @@ def test_pc_precision(precision, block_PC, wall_PC):
     Q = np.array(Q, dtype=precision)
     cb = utils.create_solver(X, Q, block_PC=block_PC, wall_PC=wall_PC)
 
-    size = 3 * cb.blobs_per_body * N_rigid + 6 * N_rigid
+    size = 3 * cb.blobs_per_rigid_body * N_rigid + 6 * N_rigid
     x = np.random.randn(size).astype(precision)
     PC = cb.apply_PC(x)
 

--- a/tests/test_wall.py
+++ b/tests/test_wall.py
@@ -11,11 +11,13 @@ def test_above_wall():
     _, config = utils.load_config(utils.struct_shell_12)
     cb = utils.create_solver(rigid_config=config, X=X, Q=Q, wall_PC=True)
 
-    size = 3 * cb.blobs_per_body * N + 6 * N
+    size = 3 * cb.blobs_per_rigid_body * N + 6 * N
     vec = np.random.randn(size)
     PC = cb.apply_PC(vec)
     saddle = cb.apply_saddle(vec)
-    M_applied = cb.apply_M(vec[: 3 * cb.blobs_per_body * N], cb.get_blob_positions())
+    M_applied = cb.apply_M(
+        vec[: 3 * cb.blobs_per_rigid_body * N], cb.get_blob_positions()
+    )
     assert np.linalg.norm(PC) > 0.0
     assert np.linalg.norm(saddle) > 0.0
     assert np.linalg.norm(M_applied) > 0.0
@@ -28,11 +30,11 @@ def test_under_wall():
     _, config = utils.load_config(utils.struct_shell_12)
     cb = utils.create_solver(rigid_config=config, X=X, Q=Q, wall_PC=True)
 
-    size = 3 * cb.blobs_per_body * N + 6 * N
+    size = 3 * cb.blobs_per_rigid_body * N + 6 * N
     vec = np.random.randn(size)
     with pytest.raises(RuntimeError):
         cb.apply_saddle(vec)
     with pytest.raises(RuntimeError):
         cb.apply_PC(vec)
     with pytest.raises(RuntimeError):
-        cb.apply_M(vec[: 3 * cb.blobs_per_body * N], cb.get_blob_positions())
+        cb.apply_M(vec[: 3 * cb.blobs_per_rigid_body * N], cb.get_blob_positions())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,8 @@ import os
 
 struct_dir = os.path.dirname(os.path.abspath(__file__)) + "/../structures/"
 struct_shell_12 = struct_dir + "shell_N_12.csv"
+struct_shell_162 = struct_dir + "shell_N_162.csv"
+struct_shell_642 = struct_dir + "shell_N_642.csv"
 
 
 def load_config(file_name):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,14 @@ def load_config(file_name):
 
 
 def create_solver(
-    X, Q, rigid_config=None, wall_PC=False, block_PC=False, fixed_config=None
+    X,
+    Q,
+    rigid_config=None,
+    wall_PC=False,
+    block_PC=False,
+    fixed_config=None,
+    a=1.0,
+    eta=1.0,
 ):
     if rigid_config is None:
         _, rigid_config = load_config(struct_shell_12)
@@ -31,8 +38,8 @@ def create_solver(
         rigid_config,
         X,
         Q,
-        a=1.0,
-        eta=1.0,
+        a=a,
+        eta=eta,
         dt=1.0,
         wall_PC=wall_PC,
         block_PC=block_PC,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,9 @@ def load_config(file_name):
     return params, cfg
 
 
-def create_solver(X, Q, rigid_config=None, wall_PC=False, block_PC=False):
+def create_solver(
+    X, Q, rigid_config=None, wall_PC=False, block_PC=False, fixed_config=None
+):
     if rigid_config is None:
         _, rigid_config = load_config(struct_shell_12)
 
@@ -32,6 +34,7 @@ def create_solver(X, Q, rigid_config=None, wall_PC=False, block_PC=False):
         dt=1.0,
         wall_PC=wall_PC,
         block_PC=block_PC,
+        fixed_config=fixed_config,
     )
 
 


### PR DESCRIPTION
This adds an `fixed_config` parameter to the constructor that takes in an (N_free x 3) list of positions of particles that are intended to stay fixed in place. When a fixed config is given, `apply_saddle` is modified to use a separate preconditioner (in python) to avoid modifying the cpp code too deeply. 

The modified `apply_saddle` is tested by creating a small wall between two particles, solving the system for a $\lambda$ with GMRES, and checking that the resulting velocities of the wall particles are zero (within tolerance) after applying an Mdot back to $\lambda$. 

One note: when using fixed structures, the corresponding segment of the RHS isn't required to be zero. This could theoretically be useful (for something like the piston example we've looked at previously), but hasn't been tested for that and makes the name `fixed_config` a questionable choice.